### PR TITLE
Externalize lucide-react via import map

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Account Management</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "lucide-react": "https://esm.sh/lucide-react"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/views/AccountView.tsx
+++ b/src/views/AccountView.tsx
@@ -20,8 +20,6 @@ import { mockUserProfile, mockPaymentMethods, mockBillingData } from '../data/mo
 
 const AccountView: React.FC = () => {
   const [userProfile, setUserProfile] = useState(mockUserProfile);
-  const [editingName, setEditingName] = useState(false);
-  const [tempName, setTempName] = useState(userProfile.name);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [paymentMethods, setPaymentMethods] = useState(mockPaymentMethods);
   const [showAddPaymentModal, setShowAddPaymentModal] = useState(false);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,5 +7,10 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  build: {
+    rollupOptions: {
+      external: ['lucide-react'],
+    },
+  },
   base: './',
 });


### PR DESCRIPTION
## Summary
- add an import map in `index.html` that points `lucide-react` to esm.sh
- configure Vite build to keep `lucide-react` external
- clean up unused state in `AccountView`

## Testing
- `npm run lint`
- `npm run build`
