### PR TITLE
Use remote ESM packages in dev

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,27 @@
-import { defineConfig } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
+
+function esmImportMapPlugin(): Plugin {
+  const imports: Record<string, string> = {
+    'lucide-react': 'https://esm.sh/lucide-react',
+    '@open-iframe-resizer/core': 'https://esm.sh/@open-iframe-resizer/core',
+  };
+
+  return {
+    name: 'esm-import-map',
+    resolveId(id) {
+      const url = imports[id];
+      if (url) {
+        return { id: url, external: true };
+      }
+      return null;
+    },
+  };
+}
 
 // https://vitejs.dev/config/ 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), esmImportMapPlugin()],
   optimizeDeps: {
     exclude: ['lucide-react', '@open-iframe-resizer/core'],
   },


### PR DESCRIPTION
## Summary
- add a Vite plugin to load `lucide-react` and `@open-iframe-resizer/core` from esm.sh during development

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev` *(started and stopped to ensure it launches)*