### PR TITLE
Fix bare react import at runtime

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,11 @@
         {
           "imports": {
             "lucide-react": "https://esm.sh/lucide-react?external=react",
-            "@open-iframe-resizer/core": "https://esm.sh/@open-iframe-resizer/core"
+            "@open-iframe-resizer/core": "https://esm.sh/@open-iframe-resizer/core",
+            "react": "https://esm.sh/react",
+            "react-dom": "https://esm.sh/react-dom",
+            "react-dom/client": "https://esm.sh/react-dom/client",
+            "react/jsx-runtime": "https://esm.sh/react/jsx-runtime"
           }
         }
       </script>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ function esmImportMapPlugin(): Plugin {
   const imports: Record<string, string> = {
     'lucide-react': 'https://esm.sh/lucide-react?external=react',
     '@open-iframe-resizer/core': 'https://esm.sh/@open-iframe-resizer/core',
+    react: 'https://esm.sh/react',
+    'react-dom': 'https://esm.sh/react-dom',
+    'react-dom/client': 'https://esm.sh/react-dom/client',
+    'react/jsx-runtime': 'https://esm.sh/react/jsx-runtime',
   };
 
   return {
@@ -27,15 +31,33 @@ export default defineConfig({
     alias: {
       'lucide-react': 'https://esm.sh/lucide-react?external=react',
       '@open-iframe-resizer/core': 'https://esm.sh/@open-iframe-resizer/core',
+      react: 'https://esm.sh/react',
+      'react-dom': 'https://esm.sh/react-dom',
+      'react-dom/client': 'https://esm.sh/react-dom/client',
+      'react/jsx-runtime': 'https://esm.sh/react/jsx-runtime',
     },
   },
   optimizeDeps: {
-    exclude: ['lucide-react', '@open-iframe-resizer/core'],
+    exclude: [
+      'lucide-react',
+      '@open-iframe-resizer/core',
+      'react',
+      'react-dom',
+      'react-dom/client',
+      'react/jsx-runtime',
+    ],
   },
   build: {
     sourcemap: true,
     rollupOptions: {
-      external: ['lucide-react', '@open-iframe-resizer/core'],
+      external: [
+        'lucide-react',
+        '@open-iframe-resizer/core',
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react/jsx-runtime',
+      ],
     },
   },
   base: './',


### PR DESCRIPTION
## Summary
- map `react` and `react-dom` modules to `esm.sh`
- update import map in `index.html`

## Testing
- `npm run build`
- `npm run lint`