### PR TITLE
Fix bare react import at runtime

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,11 @@
         {
           "imports": {
             "lucide-react": "https://esm.sh/lucide-react?external=react",
-            "@open-iframe-resizer/core": "https://esm.sh/@open-iframe-resizer/core"
+            "@open-iframe-resizer/core": "https://esm.sh/@open-iframe-resizer/core",
+            "react": "https://esm.sh/react",
+            "react-dom": "https://esm.sh/react-dom",
+            "react-dom/client": "https://esm.sh/react-dom/client",
+            "react/jsx-runtime": "https://esm.sh/react/jsx-runtime"
           }
         }
       </script>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,41 +1,44 @@
-import { defineConfig, Plugin } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig, Plugin } from 'vite'
+import react from '@vitejs/plugin-react'
+
+const cdnImports: Record<string, string> = {
+  'lucide-react': 'https://esm.sh/lucide-react?external=react',
+  '@open-iframe-resizer/core': 'https://esm.sh/@open-iframe-resizer/core',
+  react: 'https://esm.sh/react',
+  'react-dom': 'https://esm.sh/react-dom',
+  'react-dom/client': 'https://esm.sh/react-dom/client',
+  'react/jsx-runtime': 'https://esm.sh/react/jsx-runtime'
+}
+
+const externalPackages = Object.keys(cdnImports)
 
 function esmImportMapPlugin(): Plugin {
-  const imports: Record<string, string> = {
-    'lucide-react': 'https://esm.sh/lucide-react?external=react',
-    '@open-iframe-resizer/core': 'https://esm.sh/@open-iframe-resizer/core',
-  };
-
   return {
     name: 'esm-import-map',
     enforce: 'pre',
     resolveId(id) {
-      const url = imports[id];
+      const url = cdnImports[id]
       if (url) {
-        return { id: url, external: true };
+        return { id: url, external: true }
       }
-      return null;
+      return null
     },
-  };
+  }
 }
 
 // https://vitejs.dev/config/ 
 export default defineConfig({
   plugins: [react(), esmImportMapPlugin()],
   resolve: {
-    alias: {
-      'lucide-react': 'https://esm.sh/lucide-react?external=react',
-      '@open-iframe-resizer/core': 'https://esm.sh/@open-iframe-resizer/core',
-    },
+    alias: cdnImports,
   },
   optimizeDeps: {
-    exclude: ['lucide-react', '@open-iframe-resizer/core'],
+    exclude: externalPackages,
   },
   build: {
     sourcemap: true,
     rollupOptions: {
-      external: ['lucide-react', '@open-iframe-resizer/core'],
+      external: externalPackages,
     },
   },
   base: './',


### PR DESCRIPTION
## Summary
- consolidate external React CDN mappings into a single object
- use that object for alias, import map plugin, and Rollup/optimizer configuration

## Testing
- `npm run lint`
- `npm run build`
