### PR TITLE
Fix StackBlitz mkcert issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-widget-account-panel
+# widget-account-panel
+
+## Development
+
+Run the dev server using HTTP (works in StackBlitz):
+
+```bash
+npm run dev
+```
+
+To start with HTTPS using mkcert on your local machine, run:
+
+```bash
+npm run dev:https
+```
+
+This sets the `USE_MKCERT` environment variable so the Vite config enables the SSL setup.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format:check": "prettier --check .",
     "type-check": "tsc -p tsconfig.app.json --noEmit && tsc -p tsconfig.node.json --noEmit",
     "dev": "vite",
+    "dev:https": "node scripts/devhttps.mjs",
     "build": "vite build",
     "lint": "eslint .",
     "ok": "npm run format:check && npm run type-check && npm run lint && npm run build",

--- a/scripts/devhttps.mjs
+++ b/scripts/devhttps.mjs
@@ -1,0 +1,11 @@
+import { spawn } from 'child_process'
+
+const child = spawn(
+  process.platform === 'win32' ? 'npx.cmd' : 'npx',
+  ['vite'],
+  {
+    stdio: 'inherit',
+    env: { ...process.env, USE_MKCERT: '1' }
+  }
+)
+child.on('exit', (code) => process.exit(code ?? 0))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,17 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import mkcert from 'vite-plugin-mkcert'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const process: any
+
+const useMkcert =
+  process.env.USE_MKCERT === 'true' || process.env.USE_MKCERT === '1'
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss(), mkcert()],
+  plugins: useMkcert
+    ? [react(), tailwindcss(), mkcert()]
+    : [react(), tailwindcss()],
   optimizeDeps: {
     exclude: ['lucide-react']
   },
@@ -14,6 +22,6 @@ export default defineConfig({
   },
   base: './',
   server: {
-    https: true
+    https: useMkcert
   }
 })


### PR DESCRIPTION
## Summary
- add README with quick-start instructions for dev and SSL mode
- make mkcert optional via USE_MKCERT env variable
- add helper script to run dev server with mkcert

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_683be9822c80832b9b382ffe5895593b