### PR TITLE
Add account data hook and skeleton view

### DIFF
--- a/src/hooks/useAccountData.ts
+++ b/src/hooks/useAccountData.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import type { BillingData, PaymentMethod, UserProfile } from '../types/account'
+
+export interface AccountData {
+  user: UserProfile
+  paymentMethods: PaymentMethod[]
+  billing: BillingData
+}
+
+const useAccountData = () => {
+  const [data, setData] = useState<AccountData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch('/api/account')
+        if (!response.ok) throw new Error('Failed to fetch account data')
+        const json = (await response.json()) as AccountData
+        setData(json)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [])
+
+  return { data, loading }
+}
+
+export default useAccountData

--- a/src/views/AccountView.tsx
+++ b/src/views/AccountView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 // Components
 import {
@@ -10,6 +10,8 @@ import {
 import DeleteAccountModal from '../components/account/modals/DeleteAccountModal'
 import AddPaymentModal from '../components/account/modals/AddPaymentModal'
 import TopUpModal from '../components/account/modals/TopUpModal'
+import AccountViewSkeleton from './AccountViewSkeleton'
+import useAccountData from '../hooks/useAccountData'
 
 // Icons
 import { User } from 'lucide-react'
@@ -26,6 +28,7 @@ interface AccountViewProps {
 }
 
 const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
+  const { data, loading } = useAccountData()
   const [userProfile, setUserProfile] = useState<UserProfile>({
     name: '',
     email: '',
@@ -57,6 +60,14 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
   const [showTopUpModal, setShowTopUpModal] = useState(false)
   const [topUpAmount, setTopUpAmount] = useState('10')
   const [customAmount, setCustomAmount] = useState('')
+
+  useEffect(() => {
+    if (data) {
+      setUserProfile(data.user)
+      setPaymentMethods(data.paymentMethods)
+      setBillingData(data.billing)
+    }
+  }, [data])
 
   const showDeleteAccountConfirm = () => {
     setShowDeleteConfirm(true)
@@ -181,22 +192,8 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
     periodData.storage.gainedCost - periodData.storage.lostRefund
   ).toFixed(2)
 
-  if (skeleton) {
-    return (
-      <div className="animate-fadeIn animate-pulse">
-        <h1 className="text-2xl font-bold mb-6 flex items-center">
-          <User className="mr-2 text-gray-300" size={24} />
-          <div className="h-6 w-24 bg-gray-200 rounded" />
-        </h1>
-
-        <div className="space-y-6">
-          <ProfileSection skeleton />
-          <PaymentSection skeleton />
-          <BillingSection skeleton />
-          <SecuritySection skeleton />
-        </div>
-      </div>
-    )
+  if (loading || skeleton) {
+    return <AccountViewSkeleton />
   }
 
   return (

--- a/src/views/AccountViewSkeleton.tsx
+++ b/src/views/AccountViewSkeleton.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { User } from 'lucide-react'
+import {
+  ProfileSection,
+  PaymentSection,
+  BillingSection,
+  SecuritySection
+} from '../components/account'
+
+const AccountViewSkeleton: React.FC = () => {
+  return (
+    <div className="animate-fadeIn animate-pulse">
+      <h1 className="text-2xl font-bold mb-6 flex items-center">
+        <User className="mr-2 text-gray-300" size={24} />
+        <div className="h-6 w-24 bg-gray-200 rounded" />
+      </h1>
+
+      <div className="space-y-6">
+        <ProfileSection skeleton />
+        <PaymentSection skeleton />
+        <BillingSection skeleton />
+        <SecuritySection skeleton />
+      </div>
+    </div>
+  )
+}
+
+export default AccountViewSkeleton

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -1,1 +1,2 @@
 export { default as AccountView } from './AccountView'
+export { default as AccountViewSkeleton } from './AccountViewSkeleton'


### PR DESCRIPTION
## Summary
- fetch account info in new `useAccountData` hook
- render `AccountViewSkeleton` while data is loading
- update `AccountView` to hydrate state from fetched data
- export skeleton view

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683befd35f70832bafe93c1a22b37203