### PR TITLE
Use typed profile json with Artifact client

### DIFF
--- a/src/hooks/useAccountData.ts
+++ b/src/hooks/useAccountData.ts
@@ -1,34 +1,18 @@
-import { useEffect, useState } from 'react'
-import type { BillingData, PaymentMethod, UserProfile } from '../types/account'
-
-export interface AccountData {
-  user: UserProfile
-  paymentMethods: PaymentMethod[]
-  billing: BillingData
-}
+import { useExists, useTypedFile } from '@artifact/client/hooks'
+import { accountDataSchema } from '../types/account'
+import { useMemo } from 'react'
 
 const useAccountData = () => {
-  const [data, setData] = useState<AccountData | null>(null)
-  const [loading, setLoading] = useState(true)
+  const exists = useExists('profile.json')
+  const data = useTypedFile('profile.json', accountDataSchema)
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch('/api/account')
-        if (!response.ok) throw new Error('Failed to fetch account data')
-        const json = (await response.json()) as AccountData
-        setData(json)
-      } catch (err) {
-        console.error(err)
-      } finally {
-        setLoading(false)
-      }
-    }
+  const loading = useMemo(
+    () => exists === null || (exists && data === undefined),
+    [exists, data]
+  )
+  const error = exists === false ? 'profile.json not found' : null
 
-    fetchData()
-  }, [])
-
-  return { data, loading }
+  return { data, loading, error }
 }
 
 export default useAccountData

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,37 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ArtifactFrame } from '@artifact/client/react'
 import App from './App.tsx'
+import type { AccountData } from './types/account'
 import './index.css'
+
+const mockProfile: AccountData = {
+  user: {
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    profilePicture: 'https://example.com/avatar.jpg',
+  },
+  paymentMethods: [
+    {
+      id: 'ethereum1',
+      type: 'ethereum',
+      name: 'Ethereum Wallet',
+      value: '0x123...abc',
+      isConnected: true,
+    },
+  ],
+  billing: {
+    balance: 25,
+    currency: 'USD',
+    usageHistory: [],
+  },
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ArtifactFrame placeholder={<App skeleton />}>
+    <ArtifactFrame
+      placeholder={<App skeleton />}
+      {...(import.meta.env.DEV ? { mockFiles: { 'profile.json': mockProfile } } : {})}
+    >
       <App />
     </ArtifactFrame>
   </StrictMode>

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -1,40 +1,60 @@
-export interface UserProfile {
-  name: string
-  email: string
-  profilePicture: string
-}
+import { z } from 'zod'
 
-export interface PaymentMethod {
-  id: string
-  type: string
-  name: string
-  value: string
-  isConnected: boolean
-}
+export const userProfileSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  profilePicture: z.string(),
+})
 
-export interface StorageUsage {
-  gained: number
-  lost: number
-  gainedCost: number
-  lostRefund: number
-}
+export type UserProfile = z.infer<typeof userProfileSchema>
 
-export interface UsageRecord {
-  period: string
-  storage: StorageUsage
-  compute: number
-  computeCost: number
-  bandwidth: number
-  bandwidthCost: number
-  aiTokens: number
-  aiTokensCost: number
-}
+export const paymentMethodSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  name: z.string(),
+  value: z.string(),
+  isConnected: z.boolean(),
+})
 
-export interface BillingData {
-  balance: number
-  currency: string
-  usageHistory: UsageRecord[]
-}
+export type PaymentMethod = z.infer<typeof paymentMethodSchema>
+
+export const storageUsageSchema = z.object({
+  gained: z.number(),
+  lost: z.number(),
+  gainedCost: z.number(),
+  lostRefund: z.number(),
+})
+
+export type StorageUsage = z.infer<typeof storageUsageSchema>
+
+export const usageRecordSchema = z.object({
+  period: z.string(),
+  storage: storageUsageSchema,
+  compute: z.number(),
+  computeCost: z.number(),
+  bandwidth: z.number(),
+  bandwidthCost: z.number(),
+  aiTokens: z.number(),
+  aiTokensCost: z.number(),
+})
+
+export type UsageRecord = z.infer<typeof usageRecordSchema>
+
+export const billingDataSchema = z.object({
+  balance: z.number(),
+  currency: z.string(),
+  usageHistory: z.array(usageRecordSchema),
+})
+
+export type BillingData = z.infer<typeof billingDataSchema>
+
+export const accountDataSchema = z.object({
+  user: userProfileSchema,
+  paymentMethods: z.array(paymentMethodSchema),
+  billing: billingDataSchema,
+})
+
+export type AccountData = z.infer<typeof accountDataSchema>
 
 // Example account object shape
 // const AccountData: {

--- a/src/views/AccountView.tsx
+++ b/src/views/AccountView.tsx
@@ -27,7 +27,7 @@ interface AccountViewProps {
 }
 
 const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
-  const { data, loading } = useAccountData()
+  const { data, loading, error } = useAccountData()
   const [userProfile, setUserProfile] = useState<UserProfile>({
     name: '',
     email: '',
@@ -199,6 +199,11 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
         <User className="mr-2" size={24} />
         Account
       </h1>
+      {error && (
+        <p className="mb-4 text-red-600" role="alert">
+          {error}
+        </p>
+      )}
 
       <ProfileSection
         userProfile={userProfile}


### PR DESCRIPTION
## Summary
- validate account info with zod schemas
- load `profile.json` via `useTypedFile`
- show an error when the file is missing
- mock `profile.json` in dev mode

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683c20672440832bb5995a8c5c5b5bd4