### PR TITLE
Fix missing SyncerContext with mock data

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { ArtifactFrame } from '@artifact/client/react'
+import { ArtifactFrame, ArtifactSyncer } from '@artifact/client/react'
 import App from './App.tsx'
 import type { AccountData } from './types/account'
 import './index.css'
@@ -33,7 +33,9 @@ createRoot(document.getElementById('root')!).render(
       placeholder={<App skeleton />}
       {...(import.meta.env.DEV ? { mockFiles: { 'profile.json': mockProfile } } : {})}
     >
-      <App />
+      <ArtifactSyncer>
+        <App />
+      </ArtifactSyncer>
     </ArtifactFrame>
   </StrictMode>
 )


### PR DESCRIPTION
## Summary
- add ArtifactSyncer to provide context when using mock files

## Testing
- `npm run lint`
- `npm run type-check` *(fails: FATAL ERROR: heap out of memory)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683c23268338832b83731f73620bc637