### PR TITLE
Implement profile persistence

### DIFF
--- a/src/AccountView.tsx
+++ b/src/AccountView.tsx
@@ -11,6 +11,7 @@ import DeleteAccountModal from './components/modals/DeleteAccountModal'
 import AddPaymentModal from './components/modals/AddPaymentModal'
 import TopUpModal from './components/modals/TopUpModal'
 import useAccountData from './hooks/useAccountData'
+import useAccountSaver from './hooks/useAccountSaver'
 
 // Icons
 import { User } from 'lucide-react'
@@ -28,6 +29,7 @@ interface AccountViewProps {
 
 const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
   const { data, loading, error } = useAccountData()
+  const saveAccount = useAccountSaver()
   const [userProfile, setUserProfile] = useState<UserProfile>({
     name: '',
     email: '',
@@ -74,6 +76,14 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
 
   const dismissDeleteConfirm = () => {
     setShowDeleteConfirm(false)
+  }
+
+  const saveCurrentData = async (updatedProfile: UserProfile) => {
+    await saveAccount({
+      user: updatedProfile,
+      paymentMethods,
+      billing: billingData
+    })
   }
 
   const togglePaymentConnection = (id: string) => {
@@ -208,6 +218,7 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
       <ProfileSection
         userProfile={userProfile}
         setUserProfile={setUserProfile}
+        saveProfile={saveCurrentData}
         skeleton={isSkeleton}
       />
 

--- a/src/components/ProfileSection.tsx
+++ b/src/components/ProfileSection.tsx
@@ -6,12 +6,14 @@ import type { UserProfile } from '../types/account'
 interface ProfileProps {
   userProfile?: UserProfile
   setUserProfile?: React.Dispatch<React.SetStateAction<UserProfile>>
+  saveProfile?: (profile: UserProfile) => void | Promise<void>
   skeleton?: boolean
 }
 
 const ProfileSection: React.FC<ProfileProps> = ({
   userProfile,
   setUserProfile,
+  saveProfile,
   skeleton
 }) => {
   const [editingName, setEditingName] = useState(false)
@@ -42,12 +44,14 @@ const ProfileSection: React.FC<ProfileProps> = ({
     setEditingName(true)
   }
 
-  const saveName = () => {
+  const saveName = async () => {
     if (tempName.trim()) {
-      setUserProfile!({
+      const updated = {
         ...userProfile!,
         name: tempName
-      })
+      }
+      setUserProfile!(updated)
+      await saveProfile?.(updated)
     }
     setEditingName(false)
   }

--- a/src/hooks/useAccountSaver.ts
+++ b/src/hooks/useAccountSaver.ts
@@ -1,0 +1,13 @@
+import { useArtifact } from '@artifact/client/hooks'
+import type { AccountData } from '../types/account'
+
+const useAccountSaver = () => {
+  const artifact = useArtifact()
+
+  return async (data: AccountData): Promise<void> => {
+    artifact.files.write.json('profile.json', data)
+    await artifact.branch.write.commit('Update account data')
+  }
+}
+
+export default useAccountSaver

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ArtifactFrame, ArtifactSyncer } from '@artifact/client/react'
+import { HOST_SCOPE } from '@artifact/client/api'
 import App from './App.tsx'
 import type { AccountData } from './types/account'
 import './index.css'
@@ -32,6 +33,9 @@ createRoot(document.getElementById('root')!).render(
     <ArtifactFrame
       placeholder={<App skeleton />}
       mockFiles={{ 'profile.json': mockProfile }}
+      frameProps={{
+        target: { did: HOST_SCOPE.did, repo: 'mock', branch: 'main' }
+      }}
     >
       <ArtifactSyncer>
         <App />


### PR DESCRIPTION
## Summary
- add `useAccountSaver` hook for saving profile.json
- persist profile edits via Artifact when saving name
- pass frame target scope when mocking the frame

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_683e34b3b4dc832b973e186d951fc2ae